### PR TITLE
Split resource from options in fetch function

### DIFF
--- a/app-side/index.js
+++ b/app-side/index.js
@@ -10,8 +10,7 @@ function getSensorsList() {
 
 async function fetchRequest(url, path, fetchParams = {}) {
   const token = settings.settingsStorage.getItem("HAToken");
-  const res = await fetch({
-    url: new URL(path, url).toString(),
+  const res = await fetch(new URL(path, url).toString(), {
     method: "GET",
     ...fetchParams,
     headers: {


### PR DESCRIPTION
I am not sure how this works in the modified Zepp App, as I do not have it, but while trying to run this on Gadgetbridge, and even locally, I ran into the following issue:

```
Fetch API cannot load file:///android_asset/zepp_os/[object%20Object]. URL scheme "file" is not supported. (at unknown: 1)
```

It looks like the object is being stringified as a URL, resulting in a failed request.

This PR splits the url from the options, which should fix the issue. I have not been able to fully test this, as Gadgetbridge support is still not fully working, but I see the GET request hitting the server correctly.